### PR TITLE
Update Samples with Criteo SDK 3.9.0

### DIFF
--- a/appbidding_googleadmanager/build.gradle
+++ b/appbidding_googleadmanager/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 29
         versionCode 1
-        versionName "3.8.0.0"
+        versionName "3.9.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -21,5 +21,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.gms:play-services-ads:19.1.0'
-    implementation 'com.criteo.publisher:criteo-publisher-sdk:3.8.0'
+    implementation 'com.criteo.publisher:criteo-publisher-sdk:3.9.0'
 }

--- a/appbidding_mopub/build.gradle
+++ b/appbidding_mopub/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
-        versionName "3.8.0.0"
+        versionName "3.9.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -24,5 +24,5 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:17.2.1'
     implementation('com.mopub:mopub-sdk-banner:5.12.0@aar') { transitive = true }
     implementation('com.mopub:mopub-sdk-interstitial:5.12.0@aar') { transitive = true }
-    implementation 'com.criteo.publisher:criteo-publisher-sdk:3.8.0'
+    implementation 'com.criteo.publisher:criteo-publisher-sdk:3.9.0'
 }

--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 29
         versionCode 1
-        versionName "3.8.0.0"
+        versionName "3.9.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -23,6 +23,6 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:17.0.0'
     implementation 'com.google.android.gms:play-services-base:17.2.1'
-    implementation 'com.criteo.publisher:criteo-publisher-sdk:3.8.0'
+    implementation 'com.criteo.publisher:criteo-publisher-sdk:3.9.0'
     implementation 'com.squareup.picasso:picasso:2.0.0'
 }


### PR DESCRIPTION
Update dependencies on 3 modules with the latest Criteo SDK 3.9.0