### PR TITLE
Enable interstitial to be displayed on the correct listener

### DIFF
--- a/standalone/src/main/java/com/criteo/publisher/samples/standalone/InterstitialActivity.java
+++ b/standalone/src/main/java/com/criteo/publisher/samples/standalone/InterstitialActivity.java
@@ -23,6 +23,7 @@ import android.widget.Button;
 import androidx.appcompat.app.AppCompatActivity;
 import com.criteo.publisher.CriteoErrorCode;
 import com.criteo.publisher.CriteoInterstitial;
+import com.criteo.publisher.CriteoInterstitialAdDisplayListener;
 import com.criteo.publisher.CriteoInterstitialAdListener;
 
 public class InterstitialActivity extends AppCompatActivity {
@@ -51,9 +52,6 @@ public class InterstitialActivity extends AppCompatActivity {
       @Override
       public void onAdReceived() {
         // called when Criteo Ad is received, but may not necessarily ready to be displayed.
-        // always use isAdLoaded() to check if Criteo Interstitial ad is ready to be displayed.
-        displayInterstitialButton.setEnabled(true);
-        displayInterstitialButton.setText("Display Interstitial");
       }
 
       @Override
@@ -81,6 +79,22 @@ public class InterstitialActivity extends AppCompatActivity {
       @Override
       public void onAdLeftApplication() {
         // called when clicking on Criteo ad result in user leaving your application
+      }
+    });
+
+    interstitial.setCriteoInterstitialAdDisplayListener(new CriteoInterstitialAdDisplayListener() {
+      @Override
+      public void onAdReadyToDisplay() {
+        // called when Criteo Interstitial Ad is ready to be displayed
+        if (interstitial.isAdLoaded()) {
+          displayInterstitialButton.setEnabled(true);
+          displayInterstitialButton.setText("Display Interstitial");
+        }
+      }
+
+      @Override
+      public void onAdFailedToDisplay(CriteoErrorCode criteoErrorCode) {
+        // called when Criteo failed to retrieve Ad creatives
       }
     });
 


### PR DESCRIPTION
On Standalone integrations, the correct place to be able to display Interstitial ad is on `CriteoInterstitialAdDisplayListener#onAdReadyToDisplay` instead of `CriteoInterstitialAdListener#onAdReceived`.

This is to show the correct way of displaying Interstitial, if publisher wishes to display the Interstitial ad as soon as it is ready.

This dual-listeners inconvenience will later be solved in EE-923.