### PR TITLE
Remove Cleaning Keyvalues on MoPub Auto-Refresh

### DIFF
--- a/appbidding_mopub/src/main/java/com/criteo/publisher/samples/appbidding_mopub/BannerActivity.java
+++ b/appbidding_mopub/src/main/java/com/criteo/publisher/samples/appbidding_mopub/BannerActivity.java
@@ -81,17 +81,6 @@ public class BannerActivity extends AppCompatActivity {
    * @param adUnit Criteo Ad Unit object corresponds to this Banner
    */
   private void refreshCriteoBids(MoPubView banner, AdUnit adUnit) {
-    // clean previous Criteo keywords starting with "crt_"
-    StringBuilder cleanedKeywords = new StringBuilder();
-    String keywords = banner.getKeywords();
-    String[] keywordsArray = keywords.split(",");
-    for(String keyword: keywordsArray) {
-      if (!keyword.startsWith("crt_")) {
-        cleanedKeywords.append(keyword).append(",");
-      }
-    }
-    banner.setKeywords(cleanedKeywords.toString().replaceAll(",$", ""));
-
     // append new keywords, if available
     Criteo.getInstance().setBidsForAdUnit(banner, adUnit);
   }


### PR DESCRIPTION
On v3.9.0, Criteo SDK added a capability to clean existing Criteo keyvalues, before setting new ones on MoPub ad objects (https://github.com/criteo/android-publisher-sdk/pull/34)

Therefore, additional integration codes to manually clean keyvalues is no longer necessary. Also, this is to align with the public documentation https://publisherdocs.criteotilt.com/app/android/app-bidding/mopub/#handle-auto-refresh