### PR TITLE
Migrate to Criteo SDK 4.0.0 - MoPub App Bidding

### DIFF
--- a/appbidding_mopub/build.gradle
+++ b/appbidding_mopub/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
-        versionName "3.10.0.0"
+        versionName "4.0.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -24,5 +24,5 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:17.2.1'
     implementation('com.mopub:mopub-sdk-banner:5.12.0@aar') { transitive = true }
     implementation('com.mopub:mopub-sdk-interstitial:5.12.0@aar') { transitive = true }
-    implementation 'com.criteo.publisher:criteo-publisher-sdk:3.10.0'
+    implementation 'com.criteo.publisher:criteo-publisher-sdk:4.0.0'
 }

--- a/appbidding_mopub/src/main/java/com/criteo/publisher/samples/appbidding_mopub/BannerActivity.java
+++ b/appbidding_mopub/src/main/java/com/criteo/publisher/samples/appbidding_mopub/BannerActivity.java
@@ -23,6 +23,8 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import com.criteo.publisher.Bid;
+import com.criteo.publisher.BidResponseListener;
 import com.criteo.publisher.Criteo;
 import com.criteo.publisher.model.AdUnit;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -82,7 +84,14 @@ public class BannerActivity extends AppCompatActivity {
    */
   private void refreshCriteoBids(MoPubView banner, AdUnit adUnit) {
     // append new keywords, if available
-    Criteo.getInstance().setBidsForAdUnit(banner, adUnit);
+    Criteo.getInstance().loadBid(adUnit, new BidResponseListener() {
+      @Override
+      public void onResponse(@Nullable Bid bid) {
+        if (bid != null) {
+          Criteo.getInstance().enrichAdObjectWithBid(banner, bid);
+        }
+      }
+    });
   }
 
   @Override
@@ -92,8 +101,15 @@ public class BannerActivity extends AppCompatActivity {
   }
 
   private void displayBanner() {
-    Criteo.getInstance().setBidsForAdUnit(moPubView, CRITEO_BANNER_AD_UNIT);
-    moPubView.loadAd();
+    Criteo.getInstance().loadBid(CRITEO_BANNER_AD_UNIT, new BidResponseListener() {
+      @Override
+      public void onResponse(@Nullable Bid bid) {
+        if (bid != null) {
+          Criteo.getInstance().enrichAdObjectWithBid(moPubView, bid);
+        }
+        moPubView.loadAd();
+      }
+    });
   }
 
 }

--- a/appbidding_mopub/src/main/java/com/criteo/publisher/samples/appbidding_mopub/InterstitialActivity.java
+++ b/appbidding_mopub/src/main/java/com/criteo/publisher/samples/appbidding_mopub/InterstitialActivity.java
@@ -23,6 +23,8 @@ import android.os.Bundle;
 import android.widget.Button;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import com.criteo.publisher.Bid;
+import com.criteo.publisher.BidResponseListener;
 import com.criteo.publisher.Criteo;
 import com.mopub.mobileads.MoPubErrorCode;
 import com.mopub.mobileads.MoPubInterstitial;
@@ -80,8 +82,15 @@ public class InterstitialActivity extends AppCompatActivity {
 
       }
     });
-    Criteo.getInstance().setBidsForAdUnit(moPubInterstitial, CRITEO_INTERSTITIAL_AD_UNIT);
-    moPubInterstitial.load();
+    Criteo.getInstance().loadBid(CRITEO_INTERSTITIAL_AD_UNIT, new BidResponseListener() {
+      @Override
+      public void onResponse(@Nullable Bid bid) {
+        if (bid != null) {
+          Criteo.getInstance().enrichAdObjectWithBid(moPubInterstitial, bid);
+        }
+        moPubInterstitial.load();
+      }
+    });
   }
 
   private void displayInterstitial() {


### PR DESCRIPTION
Upgrade to SDKv4.0 for Mopub App Bidding
- rename project version
- update criteo-publisher-sdk:4.0.0 dependency
- replace setBidsForAdUnit with loadBid and enrichAdObjectWithBid