### PR TITLE
Reproduce "can't find referenced class" bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.7
+        uses: malinskiy/action-android/install-sdk@release/0.0.8
 
       - name: Clean and Build
         run: ./gradlew clean build

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,5 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.enableR8 = false
 

--- a/standalone/build.gradle
+++ b/standalone/build.gradle
@@ -15,6 +15,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Proguard Gradle task has warnings such as:
```
com.criteo.publisher.a0.b: can't find referenced class com.criteo.publisher.model.CacheAdUnit
```