### PR TITLE
GAM Adaptive banner

### DIFF
--- a/appbidding_googleadmanager/src/main/java/com/criteo/publisher/samples/appbidding_googleadmanager/BannerActivity.java
+++ b/appbidding_googleadmanager/src/main/java/com/criteo/publisher/samples/appbidding_googleadmanager/BannerActivity.java
@@ -19,7 +19,10 @@ package com.criteo.publisher.samples.appbidding_googleadmanager;
 import static com.criteo.publisher.samples.appbidding_googleadmanager.CriteoSampleApplication.CRITEO_BANNER_AD_UNIT;
 import static com.criteo.publisher.samples.appbidding_googleadmanager.CriteoSampleApplication.GAM_BANNER_AD_UNIT_ID;
 
+import android.graphics.Rect;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.WindowMetrics;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -31,22 +34,51 @@ import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
 
+import java.util.logging.Logger;
+
 public class BannerActivity extends AppCompatActivity {
 
   private AdManagerAdView adManagerAdView;
+  private FrameLayout publisherAdViewContainer;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_banner);
 
+    publisherAdViewContainer = findViewById(R.id.publisherAdViewContainer);
+
+    AdSize adSize = getAdSize();
+    Log.d("CriteoSdk", String.format("%d x %d", adSize.getWidth(), adSize.getHeight()));
+
     adManagerAdView = new AdManagerAdView(this);
-    adManagerAdView.setAdSizes(AdSize.BANNER);
+    adManagerAdView.setAdSizes(adSize, AdSize.BANNER);
     adManagerAdView.setAdUnitId(GAM_BANNER_AD_UNIT_ID);
-    FrameLayout publisherAdViewContainer = findViewById(R.id.publisherAdViewContainer);
     publisherAdViewContainer.addView(adManagerAdView);
 
     displayBanner();
+  }
+
+  // Determine the screen width (less decorations) to use for the ad width.
+  private AdSize getAdSize() {
+    WindowMetrics windowMetrics = null;
+    Rect bounds = null;
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+      windowMetrics = getWindowManager().getCurrentWindowMetrics();
+      bounds = windowMetrics.getBounds();
+    }
+
+    float adWidthPixels = publisherAdViewContainer.getWidth();
+
+    // If the ad hasn't been laid out, default to the full screen width.
+    if (adWidthPixels == 0f) {
+      adWidthPixels = bounds.width();
+    }
+
+    float density = getResources().getDisplayMetrics().density;
+    int adWidth = (int) (adWidthPixels / density);
+
+    return AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(this, adWidth);
   }
 
   @Override

--- a/appbidding_googleadmanager/src/main/java/com/criteo/publisher/samples/appbidding_googleadmanager/CriteoSampleApplication.java
+++ b/appbidding_googleadmanager/src/main/java/com/criteo/publisher/samples/appbidding_googleadmanager/CriteoSampleApplication.java
@@ -58,6 +58,7 @@ public class CriteoSampleApplication extends Application {
     try {
       new Criteo.Builder(this, CRITEO_PUBLISHER_ID)
           .adUnits(criteoAdUnits)
+              .debugLogsEnabled(true)
           .init();
     } catch (CriteoInitException e) {
       Log.d("Ads", "Failed to initialize Criteo SDK", e);


### PR DESCRIPTION
A sample implementation of how Criteo SDK can bid on GAM adaptive banner implementation.
This requires minimal changes on GAM line items, i.e. ensure that 4 banner sizes are defined in the line items: 300x50, 320x50, 300x100, 320x100. This also ensures compatibility with 3PD.

Specs: https://criteo.atlassian.net/wiki/spaces/SPS/pages/2244902917/Google+Ad+Manager+Adaptive+Banner+Integration